### PR TITLE
Handle digits that are in names.

### DIFF
--- a/src/parse/__tests__/td3.js
+++ b/src/parse/__tests__/td3.js
@@ -114,4 +114,64 @@ describe('parse TD3', () => {
       compositeCheckDigit: '0',
     });
   });
+
+  it('digits in name', () => {
+    //Notice how we put a number (0) as part of the surname - In cases where we have misinterpreted an O as a 0
+    const MRZ = [
+      'P<UTOERIKSS0N<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<',
+      'L898902C36UTO7408122F1204159ZE184226B<<<<<10',
+    ];
+
+    const result = parse(MRZ);
+    expect(result).toMatchObject({
+      valid: false,
+      format: 'TD3',
+    });
+    expect(result.valid).toBe(false);
+    const errors = result.details.filter((a) => !a.valid);
+    expect(errors).toHaveLength(2);
+    expect(result.fields).toStrictEqual({
+      documentCode: 'P',
+      firstName: 'ANNA MARIA',
+      lastName: 'ERIKSSON',
+      documentNumber: 'L898902C3',
+      documentNumberCheckDigit: '6',
+      nationality: null,
+      sex: 'female',
+      expirationDate: '120415',
+      expirationDateCheckDigit: '9',
+      personalNumber: 'ZE184226B',
+      personalNumberCheckDigit: '1',
+      birthDate: '740812',
+      birthDateCheckDigit: '2',
+      issuingState: null,
+      compositeCheckDigit: '0',
+    });
+
+    const personalNumberDetails = result.details.find(
+        (d) => d.field === 'personalNumber',
+    );
+    expect(personalNumberDetails).toStrictEqual({
+      label: 'Personal number',
+      field: 'personalNumber',
+      value: 'ZE184226B',
+      valid: true,
+      ranges: [{ line: 1, start: 28, end: 42, raw: 'ZE184226B<<<<<' }],
+      line: 1,
+      start: 28,
+      end: 37,
+    });
+
+    expect(errors[0]).toStrictEqual({
+      label: 'Issuing state',
+      field: 'issuingState',
+      value: null,
+      valid: false,
+      ranges: [{ line: 0, start: 2, end: 5, raw: 'UTO' }],
+      line: 0,
+      start: 2,
+      end: 5,
+      error: 'invalid state code: UTO',
+    });
+  });
 });

--- a/src/parse/getResult.js
+++ b/src/parse/getResult.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const formats = require('../formats');
+
 function getDetails(lines, fieldParsers) {
   const details = [];
   for (const parser of fieldParsers) {
@@ -21,6 +23,7 @@ function getFields(details) {
 }
 
 function getResult(format, lines, fieldParsers) {
+  lines = cleanInvalidCharactersInName(format, lines);
   const details = getDetails(lines, fieldParsers);
   const fields = getFields(details);
   const result = {
@@ -30,6 +33,27 @@ function getResult(format, lines, fieldParsers) {
     valid: fields.valid,
   };
   return result;
+}
+
+function cleanInvalidCharactersInName(format, lines) {
+  const commonNumberToLetterMismatches = {
+    '8':'B', '6':'G', '0':'O', '3':'E', '1':'I', '5':'S', '2':'Z'
+  }
+
+  const keys = Object.keys(commonNumberToLetterMismatches);
+
+  switch (format) {
+    case formats.TD3:
+      let topLine = lines[0].split("");
+      lines[0] = topLine.map(v => {
+        if (keys.includes(v)) {
+          v = commonNumberToLetterMismatches[v] === undefined ? v : commonNumberToLetterMismatches[v];
+        }
+        return v;
+      }).join(',').replaceAll(',','');
+      break;
+  }
+  return lines;
 }
 
 module.exports = getResult;


### PR DESCRIPTION
There are scenarios where the names and/or other details in the first element from the MRZ code array are represented by digits instead of characters. For exampe, P<UTO3RIKSS0N<<ANNA<MARIA<<<<<<<<<<<<<<<<<<< instead of P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<.

This fix serves to handle these kind of scenarios so that digits are mapped to there correct/right equivalent Characters so that we do not have issues when applying regex checks on the results.