### PR TITLE
Added code for Kosovo as it is used in EU temporary residence IDs.

### DIFF
--- a/builder/states.txt
+++ b/builder/states.txt
@@ -8,6 +8,8 @@ British Protected Person _ GBP
 Republic of Kosovo KS RKS
 # Manually add Germany is it uses an invalid code
 Germany DE D
+# Temporary country code for Kosovo in use in the EU
+Kosovo XK XXK
 
 # Part B - Other Codes Reserved by ISO 3166/MA
 European Union (EU) _ EUE

--- a/src/generated/__tests__/states.test.ts
+++ b/src/generated/__tests__/states.test.ts
@@ -10,7 +10,7 @@ describe('check countries', function () {
         expect(code).toHaveLength(3);
       }
     }
-    expect(codes).toHaveLength(276);
+    expect(codes).toHaveLength(277);
     expect(states.CHE).toBe('Switzerland');
     expect(states.DEU).toBe('Germany');
   });

--- a/src/generated/states.ts
+++ b/src/generated/states.ts
@@ -256,6 +256,7 @@ const states = {
   "GBP": "British Protected Person",
   "RKS": "Republic of Kosovo",
   "D": "Germany",
+  "XXK": "Kosovo",
   "EUE": "European Union (EU)",
   "UNO": "United Nations Organization or one of its officials",
   "UNA": "United Nations specialized agency or one of its officials",


### PR DESCRIPTION
Added code for Kosovo as mentioned here:
https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#User-assigned_code_elements

Code is present in MRZ of Residence permits ID cards circulating in Germany.