### PR TITLE
fix: fix autocorrections being assigned to the wrong field

### DIFF
--- a/src/parse/__tests__/swissDrivingLicense.test.ts
+++ b/src/parse/__tests__/swissDrivingLicense.test.ts
@@ -92,11 +92,11 @@ describe('parse Swiss Driving License', () => {
         { line: 1, column: 24, original: 'G', corrected: '6' },
       ],
       [],
+      [],
       [
         { line: 2, column: 12, original: '8', corrected: 'B' },
         { line: 2, column: 13, original: '1', corrected: 'I' },
       ],
-      [],
     ]);
   });
 });

--- a/src/parse/__tests__/td1.test.ts
+++ b/src/parse/__tests__/td1.test.ts
@@ -191,10 +191,11 @@ describe('parse TD1', () => {
       [
         { line: 2, column: 0, original: '5', corrected: 'S' },
         { line: 2, column: 2, original: '1', corrected: 'I' },
+      ],
+      [
         { line: 2, column: 8, original: '0', corrected: 'O' },
         { line: 2, column: 14, original: '8', corrected: 'B' },
       ],
-      [],
     ]);
   });
 });

--- a/src/parse/__tests__/td2.test.ts
+++ b/src/parse/__tests__/td2.test.ts
@@ -56,9 +56,8 @@ describe('parse TD2', () => {
       [
         { line: 0, column: 9, original: '5', corrected: 'S' },
         { line: 0, column: 10, original: '5', corrected: 'S' },
-        { line: 0, column: 23, original: '1', corrected: 'I' },
       ],
-      [],
+      [{ line: 0, column: 23, original: '1', corrected: 'I' }],
       [],
       [],
       [{ line: 1, column: 12, original: '0', corrected: 'O' }],


### PR DESCRIPTION
This happened when multiple field use the same range as the source for parsing.

Stopped using previous autocorrected lines to compute next autocorrection and remove any autocorrection that does not finally apply to the final character range of the field.
