### PR TITLE
fix: add support for French national id with no administrative code

### DIFF
--- a/src/parse/__tests__/frenchNationalId.test.ts
+++ b/src/parse/__tests__/frenchNationalId.test.ts
@@ -34,6 +34,39 @@ describe('parse French National Id', () => {
     expect(result.details.filter((a) => !a.valid)).toHaveLength(0);
   });
 
+  it('valid MRZ with no administrative code', () => {
+    const MRZ = [
+      'IDFRABERTHIER<<<<<<<<<<<<<<<<<<<<<<<',
+      '9409923102854CORINNE<<<<<<<6512068F4',
+    ];
+
+    const result = parse(MRZ);
+
+    expect(result).toMatchObject({
+      format: 'FRENCH_NATIONAL_ID',
+      valid: true,
+      documentNumber: '940992310285',
+    });
+
+    expect(result.fields).toStrictEqual({
+      documentCode: 'ID',
+      issuingState: 'FRA',
+      lastName: 'BERTHIER',
+      administrativeCode: '',
+      issueDate: '9409',
+      administrativeCode2: '923',
+      documentNumber: '10285',
+      documentNumberCheckDigit: '4',
+      firstName: 'CORINNE',
+      birthDate: '651206',
+      birthDateCheckDigit: '8',
+      sex: 'female',
+      compositeCheckDigit: '4',
+    });
+
+    expect(result.details.filter((a) => !a.valid)).toHaveLength(0);
+  });
+
   it('invalid MRZ', () => {
     const MRZ = [
       'IDFRATEST<NAME<<<<<<<<<<<<<<<<0CHE02',

--- a/src/parse/parse.ts
+++ b/src/parse/parse.ts
@@ -29,8 +29,10 @@ function parseMRZ(
         case 30:
           return parsers.td1(lines, options);
         case 36: {
-          const endLine1 = lines[0].substring(30, 66);
-          if (endLine1.match(/[0-9]/)) {
+          if (
+            lines[0].substring(30, 35).match(/[0-9]/) ||
+            lines[0].match(/^IDFRA/)
+          ) {
             return parsers.frenchNationalId(lines, options);
           } else {
             return parsers.td2(lines, options);


### PR DESCRIPTION
This PR adds support for the french national IDs that have no administrative code (last 6 characters in the first line).

An example of such IDs can be found on [PRADO](https://www.consilium.europa.eu/prado/en/FRA-BO-02002/index.html):

![image](https://github.com/user-attachments/assets/50e1e37a-c79b-47b2-a56c-bb4e2ac432a3)

Also, [Wikipedia](https://en.wikipedia.org/wiki/National_identity_card_(France)) states that these last 6 characters are left empty for some IDs.

![image](https://github.com/user-attachments/assets/7463afb9-e503-49d1-a56e-f14baed3aa15)
